### PR TITLE
Add Regula - EU AI Act code scanner (Python CLI, 8 languages, MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.
 - [AIR Blackbox](https://github.com/airblackbox) - Open-source trust infrastructure with 39 EU AI Act compliance checks, decision traceability, and audit chains across 11 PyPI packages.
+- [Regula](https://github.com/kuzivaai/getregula) - Static code scanner for EU AI Act risk indicators across 8 language families (404 regex patterns, 12 compliance framework mappings). Stdlib-only Python, zero dependencies, fully offline. GitHub Action with SARIF and PR comments.
 
 ### Risk Assessment & Classification
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.
 - [AIR Blackbox](https://github.com/airblackbox) - Open-source trust infrastructure with 39 EU AI Act compliance checks, decision traceability, and audit chains across 11 PyPI packages.
-- [Regula](https://github.com/kuzivaai/getregula) - Static code scanner for EU AI Act risk indicators across 8 language families (404 regex patterns, 12 compliance framework mappings). Stdlib-only Python, zero dependencies, fully offline. GitHub Action with SARIF and PR comments.
 
 ### Risk Assessment & Classification
 
 - [AI Assessment Tool (AI4Belgium)](https://github.com/AI4Belgium/ai-assessment-tool) - Open-source interactive tool based on ALTAI recommendations for assessing AI trustworthiness.
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
+- [Regula](https://github.com/kuzivaai/getregula) — CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
 
 ### Educational & Informational
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@
 - [AI Assessment Tool (AI4Belgium)](https://github.com/AI4Belgium/ai-assessment-tool) - Open-source interactive tool based on ALTAI recommendations for assessing AI trustworthiness.
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
-- [Regula](https://github.com/kuzivaai/getregula) — CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
+- [Regula](https://github.com/kuzivaai/getregula) - CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
 
 ### Educational & Informational
 


### PR DESCRIPTION
  ## What are you adding or changing?

  Adding Regula, an open-source CLI that scans source code for EU AI Act compliance risks.

  - **Repo:** https://github.com/kuzivaai/getregula
  - **Licence:** MIT + EUPL-1.2
  - **Install:** `pipx install regula-ai`
  - **What it does:** 404 regex patterns across 52 risk categories, 8 language families, 12 compliance framework mappings, zero
  runtime dependencies, fully offline, GitHub Action with SARIF

  ## Checklist

  - [x] I have read CONTRIBUTING.md
  - [x] The link is publicly accessible and currently working
  - [x] The entry follows the format: `- [Name](URL) — One-sentence description.`
  - [x] The description is factual and under 100 characters (no marketing language)
  - [x] The resource is placed in the correct section
  - [x] The resource is not already listed in the README
  - [x] The resource is directly relevant to EU AI Act compliance or understanding