### PR TITLE
Add TinyTools AI Content Disclosure Generator (Article 50 disclosures)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [Hyperproof](https://hyperproof.io/) - Compliance operations with automation for evidence collection and control mapping.
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
+- [TinyTools AI Content Disclosure Generator](https://tinytools-smoky.vercel.app/) - Free browser-based generator for Article 50 / 50.4 EU AI Act compliance disclosures (HTML, JSON-LD, plain-text). Part of TinyTools, a small open-source collection of free, no-signup web utilities.
 ---
 
 ## Open-Source Projects


### PR DESCRIPTION
Hi! Adding TinyTools AI Content Disclosure Generator — a free, browser-based tool for generating Article 50 / 50.4 EU AI Act compliance disclosures.

What it does:
- Generates Article 50 transparency notices (for AI system providers and deployers)
- Outputs in three formats: HTML snippet, JSON-LD, and plain-text
- Runs entirely in the browser (no signup, no data collection)
- Open source

Live: https://tinytools-smoky.vercel.app/

I added it next to AI Disclosure Kit in the EU AI Act-Specific Tools subsection since they cover similar territory. Happy to rename, reposition, or expand the description if needed. Thanks for maintaining this list — it'''s a great resource!