### PR TITLE
Add: General-Purpose AI Code of Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Regulation Text](#regulation-text)
   - [European Commission](#european-commission)
   - [EU AI Office](#eu-ai-office)
+  - [GPAI Code of Practice](#gpai-code-of-practice)
   - [European Parliament & Governance](#european-parliament--governance)
   - [Unofficial Authoritative References](#unofficial-authoritative-references)
 - [Compliance Tools & Platforms](#compliance-tools--platforms)
@@ -90,6 +91,10 @@
 - [European AI Office](https://digital-strategy.ec.europa.eu/en/policies/ai-office) - Coordinates AI Act implementation and enforces GPAI rules.
 - [AI Act Single Information Platform](https://ai-act-service-desk.ec.europa.eu/en) - Interactive compliance tools, AI Act Explorer, Compliance Checker, and FAQs.
 - [EU AI Act Compliance Checker (EC)](https://ai-act-service-desk.ec.europa.eu/en/eu-ai-act-compliance-checker) - Official beta tool for determining obligations.
+
+### GPAI Code of Practice
+
+- [General-Purpose AI Code of Practice](https://code-of-practice.ai/) — Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
 
 ### European Parliament & Governance
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@
 
 ### GPAI Code of Practice
 
-- [General-Purpose AI Code of Practice](https://code-of-practice.ai/) — Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
+- [General-Purpose AI Code of Practice](https://code-of-practice.ai/) - Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
 
 ### European Parliament & Governance
 


### PR DESCRIPTION
Adds the General-Purpose AI Code of Practice to a new "GPAI Code of Practice" subsection under "Official EU Sources".

**What it is:** The voluntary Code drafted by 13 independent experts and endorsed by the Commission, which GPAI providers can use to demonstrate compliance with Articles 53 and 55 of the AI Act. It has been in application since 2 August 2025 and is signed by OpenAI, Anthropic, Google, and others.

**Why it belongs:** Currently the list has no entry for the Code of Practice anywhere. It's the central voluntary compliance instrument for GPAI providers under the AI Act.

**Checklist:**
- [x] Directly relevant to EU AI Act compliance
- [x] Publicly accessible
- [x] Working link
- [x] Not already listed
- [x] Description under 100 characters
- [x] Table of contents updated