### PR TITLE
Add gpai code commission page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 ### GPAI Code of Practice
 
 - [General-Purpose AI Code of Practice](https://code-of-practice.ai/) — Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
-- [GPAI Code of Practice (European Commission)](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai) — Official Commission page with the GPAI Code of Practice signatory list, signature process, and Q&A.
+- [GPAI Code of Practice (European Commission)](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai) - Official Commission page with the GPAI Code of Practice signatory list, signature process, and Q&A.
 
 ### European Parliament & Governance
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@
 
 ### GPAI Code of Practice
 
-- [General-Purpose AI Code of Practice](https://code-of-practice.ai/) — Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
+- [General-Purpose AI Code of Practice](https://code-of-practice.ai/) - Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
 - [GPAI Code of Practice (European Commission)](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai) - Official Commission page with the GPAI Code of Practice signatory list, signature process, and Q&A.
 
 ### European Parliament & Governance

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 ### GPAI Code of Practice
 
 - [General-Purpose AI Code of Practice](https://code-of-practice.ai/) — Voluntary tool for GPAI providers to demonstrate AI Act compliance on transparency, copyright, and safety.
+- [GPAI Code of Practice (European Commission)](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai) — Official Commission page with the GPAI Code of Practice signatory list, signature process, and Q&A.
 
 ### European Parliament & Governance
 


### PR DESCRIPTION
Adds the European Commission's official landing page for the GPAI Code of Practice to the "GPAI Code of Practice" subsection under "Official EU Sources".

**What it is:** The Commission's official page hosting the signatory list, the Signatory Form and signature process, the Vademecum, and Q&A about the Code. Distinct from the Code text itself (which is at code-of-practice.ai).

**Why it belongs:** It's the authoritative source for which providers have signed the Code and how to sign it — information not available on the Code text site. Complements the Code text entry without duplicating it.

**Note:** This PR depends on  #12  being merged first. If PR #12 is rejected, please close this one too.

**Checklist:**
- [x] Directly relevant to EU AI Act compliance
- [x] Publicly accessible
- [x] Working link
- [x] Not already listed
- [x] Description under 100 characters
