### PR TITLE
Add ai-act-skills — multi-platform agent skill (Claude Code + Gemini CLI + Codex), ISO 42001+27090 anchoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
 
 ### EU AI Act Compliance Platforms
 
+- [ai-act-skills](https://github.com/abk1969/ai-act-skills) - Multi-platform agent skill running natively on Claude Code, Gemini CLI, and OpenAI Codex. Strict ISO/IEC 42001:2023 (AIMS) + 27090:2025 (AI cybersecurity) anchoring — never ISO 27001 as primary AI framework. Citation-grade: every obligation cites article + clause + Annex A control (e.g., art. 9(2)(a) → cl. 6.1.4 + A.5.4). 15 reference files covering risk classification, FRIA (art. 27), Annex IV, post-market, GPAI, sandboxes, AI literacy (art. 4). Machine-readable SSL manifest per arXiv:2604.24026. Reference-only — no network, no credentials, no tool calls. MIT.
 - [VerifyWise](https://github.com/verifywise-ai/verifywise) - Complete AI governance and LLM evals platform with support for EU AI Act, ISO 42001, NIST AI RMF, and 20+ frameworks (~247 stars).
 - [EuConform](https://github.com/Hiepler/EuConform) - Risk classification, bias detection via CrowS-Pairs, and Annex IV-compliant PDF report generation, 100% offline (~107 stars).
 - [EU AI Act MCP Server](https://github.com/SonnyLabs/EU_AI_ACT_MCP) - MCP server with compliance tools including risk classification, prohibited practice checks, and transparency disclosures.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@
 
 ### EU AI Act Compliance Platforms
 
-- [ai-act-skills](https://github.com/abk1969/ai-act-skills) - Multi-platform agent skill running natively on Claude Code, Gemini CLI, and OpenAI Codex. Strict ISO/IEC 42001:2023 (AIMS) + 27090:2025 (AI cybersecurity) anchoring — never ISO 27001 as primary AI framework. Citation-grade: every obligation cites article + clause + Annex A control (e.g., art. 9(2)(a) → cl. 6.1.4 + A.5.4). 15 reference files covering risk classification, FRIA (art. 27), Annex IV, post-market, GPAI, sandboxes, AI literacy (art. 4). Machine-readable SSL manifest per arXiv:2604.24026. Reference-only — no network, no credentials, no tool calls. MIT.
+- [ai-act-skills](https://github.com/abk1969/ai-act-skills) - Multi-platform agent skills for EU AI Act compliance workflows anchored in ISO/IEC 42001 and ISO/IEC 27090.
 - [VerifyWise](https://github.com/verifywise-ai/verifywise) - Complete AI governance and LLM evals platform with support for EU AI Act, ISO 42001, NIST AI RMF, and 20+ frameworks (~247 stars).
 - [EuConform](https://github.com/Hiepler/EuConform) - Risk classification, bias detection via CrowS-Pairs, and Annex IV-compliant PDF report generation, 100% offline (~107 stars).
 - [EU AI Act MCP Server](https://github.com/SonnyLabs/EU_AI_ACT_MCP) - MCP server with compliance tools including risk classification, prohibited practice checks, and transparency disclosures.


### PR DESCRIPTION
Adds an entry for [`ai-act-skills`](https://github.com/abk1969/ai-act-skills) under **Open-Source Projects → EU AI Act Compliance Platforms**, alphabetically placed first.

## What it is

The first multi-platform agent skill for EU AI Act compliance. Runs natively on Claude Code, Gemini CLI, and OpenAI Codex with the same regulatory content (15 references, SSL manifest, citation-grade article + clause + control mappings).

## Why it fits this list / this section

- **EU AI Act-specific** — codifies Regulation 2024/1689; not a general governance toolkit
- **ISO 42001 + 27090 anchored** — explicitly avoids ISO 27001 as the AI-specific framework
- **Open source (MIT)** — community-maintainable
- **Complementary to existing entries** — `compl-ai` evaluates models; `ark-forge/mcp-eu-ai-act` scans codebases; this skill codifies the regulation. They're three different categories.

## Verifiable claims

- 15 reference files covering risk classification, FRIA, Annex IV, post-market, GPAI, sandboxes, AI literacy: [`skills/ai-act-compliance/references/`](https://github.com/abk1969/ai-act-skills/tree/main/skills/ai-act-compliance/references)
- Multi-platform contract documented: [`references/15-platform-compatibility.md`](https://github.com/abk1969/ai-act-skills/blob/main/skills/ai-act-compliance/references/15-platform-compatibility.md)
- Reference-only profile (`tool_calls: false`) declared in [`ssl.json`](https://github.com/abk1969/ai-act-skills/blob/main/skills/ai-act-compliance/ssl.json) and verifiable via `grep` across SKILL.md and references
- SSL manifest per [arXiv:2604.24026](https://arxiv.org/abs/2604.24026)
- Latest release: [v1.2.2](https://github.com/abk1969/ai-act-skills/releases/tag/v1.2.2) (2026-05-09)

## Decision-support note

The skill is decision-support only, not legal advice. This is stated explicitly in SKILL.md, README.md, NOTICE, and CONTRIBUTING.md. Consistent with the awesome list's existing curation policy.

Thanks for maintaining this list — it's the canonical reference for the niche.