### PR TITLE
Add: Guidelines on Prohibited AI Practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [European Approach to Artificial Intelligence](https://digital-strategy.ec.europa.eu/en/policies/european-approach-artificial-intelligence) - Overarching EU AI strategy and AI Continent Action Plan.
 - [AI Act Standardisation](https://digital-strategy.ec.europa.eu/en/policies/ai-act-standardisation) - Official page on CEN/CENELEC harmonized standards in ten key areas.
 - [Supporting Implementation with Clear Guidelines](https://digital-strategy.ec.europa.eu/en/news/supporting-implementation-ai-act-clear-guidelines) - Published and upcoming guidelines on prohibited practices, high-risk classification, and transparency.
+- [Guidelines on Prohibited AI Practices](https://digital-strategy.ec.europa.eu/en/library/commission-publishes-guidelines-prohibited-artificial-intelligence-ai-practices-defined-ai-act) - Commission's interpretation of Article 5 prohibitions with practical examples (4 February 2025).
 - [AI Literacy Q&A](https://digital-strategy.ec.europa.eu/en/faqs/ai-literacy-questions-answers) - Official FAQ on AI literacy obligations under Article 4.
 - [AI Pact](https://digital-strategy.ec.europa.eu/en/policies/ai-pact) - Voluntary initiative enabling early compliance before legal deadlines.
 


### PR DESCRIPTION
Adds the European Commission's Guidelines on Prohibited AI Practices to the "European Commission" subsection under "Official EU Sources".

**What it is:** The Commission's non-binding guidelines (4 February 2025) interpreting Article 5 prohibitions — manipulation, exploitation of vulnerabilities, social scoring, biometric scraping, emotion recognition, real-time remote biometric identification, and predictive policing. Available in all 24 EU official languages.

**Why it belongs:** Article 5 prohibitions entered into application on 2 February 2025 and are enforceable since 2 August 2025, with fines up to €35M or 7% of worldwide turnover. The Guidelines are the Commission's primary interpretive document on Article 5 and are cited by most law-firm guides already on this list. The list currently links to the umbrella "Supporting Implementation with Clear Guidelines" page but not to the Guidelines themselves.

**Checklist:**
- [x] Directly relevant to EU AI Act compliance
- [x] Publicly accessible
- [x] Working link
- [x] Not already listed
- [x] Description under 100 characters
- [x] Hyphen separator (passes awesome-lint)
