### PR TITLE
Add: Guidelines on the Scope of Obligations for GPAI Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [European Approach to Artificial Intelligence](https://digital-strategy.ec.europa.eu/en/policies/european-approach-artificial-intelligence) - Overarching EU AI strategy and AI Continent Action Plan.
 - [AI Act Standardisation](https://digital-strategy.ec.europa.eu/en/policies/ai-act-standardisation) - Official page on CEN/CENELEC harmonized standards in ten key areas.
 - [Supporting Implementation with Clear Guidelines](https://digital-strategy.ec.europa.eu/en/news/supporting-implementation-ai-act-clear-guidelines) - Published and upcoming guidelines on prohibited practices, high-risk classification, and transparency.
+- [Guidelines on the Scope of Obligations for Providers of GPAI Models](https://digital-strategy.ec.europa.eu/en/policies/guidelines-gpai-providers) - Commission interpretation of GPAI definition, the 10²³ FLOP threshold, and downstream-provider duties.
 - [AI Literacy Q&A](https://digital-strategy.ec.europa.eu/en/faqs/ai-literacy-questions-answers) - Official FAQ on AI literacy obligations under Article 4.
 - [AI Pact](https://digital-strategy.ec.europa.eu/en/policies/ai-pact) - Voluntary initiative enabling early compliance before legal deadlines.
 


### PR DESCRIPTION
Adds the European Commission's Guidelines on the Scope of Obligations for Providers of GPAI Models to the "European Commission" subsection under "Official EU Sources".

**What it is:** The Commission's guidelines (18 July 2025) clarifying who counts as a GPAI provider under Articles 53–55. Covers: the 10²³ FLOP threshold for GPAI classification and 10²⁵ FLOP threshold for systemic risk, the rules for downstream providers who fine-tune or modify a GPAI model, lifecycle obligations from pre-training onward, open-source exemptions, and the relationship between GPAI models and AI systems built on them.

**Why it belongs:** GPAI obligations entered into application on 2 August 2025. These Guidelines are the Commission's primary interpretive document on Articles 53–55 and complement both the GPAI Code of Practice (PR #1, if merged) and the Training Content Template. They're the authoritative answer to "does my model count as GPAI?" and "what happens when I fine-tune one?".

**Checklist:**
- [x] Directly relevant to EU AI Act compliance
- [x] Publicly accessible
- [x] Working link
- [x] Not already listed
- [x] Description under 100 characters
- [x] Hyphen separator