### PR TITLE
Add: Public Summary of Training Content Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Practical templates, checklists, and assessment materials for AI Act readiness, 
 - [Annex IV: Technical Documentation Requirements (FLI)](https://artificialintelligenceact.eu/annex/4/) - Official text specifying what must be included.
 - [Article 11: Technical Documentation (FLI)](https://artificialintelligenceact.eu/article/11/) - Requirements including simplified forms for SMEs.
 - [Article 17: Quality Management System (FLI)](https://artificialintelligenceact.eu/article/17/) - Full legal text of QMS requirements with 13 mandatory elements.
+- [Public Summary of Training Content Template (EC)](https://digital-strategy.ec.europa.eu/en/library/explanatory-notice-and-template-public-summary-training-content-general-purpose-ai-models) - Mandatory Article 53(1)(d) template for GPAI providers to publicly summarise training data.
 
 ### Timeline & Governance Infographics
 


### PR DESCRIPTION
Adds the European Commission's mandatory Public Summary of Training Content Template to the "Technical Documentation (Annex IV)" subsection under "Templates & Checklists".

**What it is:** The mandatory template (24 July 2025) every GPAI provider must use to publicly disclose a summary of training data under Article 53(1)(d) AI Act. Covers data modalities, datasets, sources, copyright opt-out compliance under Article 4 CDSM, and content moderation measures. Available with explanatory notice in all 24 EU official languages, plus a separate Q&A.

**Why it belongs:** This is the *only* mandatory template for Article 53(1)(d) compliance — not voluntary like the GPAI Code of Practice. All GPAI providers, including open-source ones, must use it. The "Templates & Checklists" section already includes FRIA and Annex IV technical documentation references but is missing the training content summary template, which is now the most-consulted compliance artifact for GPAI providers.

**Checklist:**
- [x] Directly relevant to EU AI Act compliance
- [x] Publicly accessible
- [x] Working link
- [x] Not already listed
- [x] Description under 100 characters
- [x] Hyphen separator