### PR TITLE
Add Audaria — FR editorial observatory on EU AI Act & ISO 42001

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Practical templates, checklists, and assessment materials for AI Act readiness, 
 ### Websites & Blogs
 
 - [EU AI Act Updates & Compliance (Cyber Risk GmbH)](https://www.artificial-intelligence-act.com/) - Compliance-oriented resource with updates, training materials, and implementation timelines.
+- [Audaria — EU AI Act & ISO 42001 Observatory (FR)](https://audaria.fr/) - French-language editorial coverage of Article 26 deployer obligations, FRIA Article 27, and ISO/IEC 42001 implementation for SMEs.
 
 ### Podcasts
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Practical templates, checklists, and assessment materials for AI Act readiness, 
 ### Websites & Blogs
 
 - [EU AI Act Updates & Compliance (Cyber Risk GmbH)](https://www.artificial-intelligence-act.com/) - Compliance-oriented resource with updates, training materials, and implementation timelines.
-- [Audaria](https://audaria.fr/) — French-language coverage of the EU AI Act, ISO/IEC 42001, and AI governance for SMEs.
+- [Audaria](https://audaria.fr/) - French-language coverage of the EU AI Act, ISO/IEC 42001, and AI governance for SMEs.
 
 ### Podcasts
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Practical templates, checklists, and assessment materials for AI Act readiness, 
 ### Websites & Blogs
 
 - [EU AI Act Updates & Compliance (Cyber Risk GmbH)](https://www.artificial-intelligence-act.com/) - Compliance-oriented resource with updates, training materials, and implementation timelines.
-- [Audaria — EU AI Act & ISO 42001 Observatory (FR)](https://audaria.fr/) - French-language editorial coverage of Article 26 deployer obligations, FRIA Article 27, and ISO/IEC 42001 implementation for SMEs.
+- [Audaria](https://audaria.fr/) — French-language coverage of the EU AI Act, ISO/IEC 42001, and AI governance for SMEs.
 
 ### Podcasts
 


### PR DESCRIPTION
Adds **Audaria** (https://audaria.fr/) to the *Websites & Blogs* section.

- **Language**: French
- **Scope**: Editorial coverage of EU AI Act (Article 26 deployer obligations, FRIA Article 27, Annex III) and ISO/IEC 42001 implementation
- **Audience**: French SMEs and mid-cap companies
- **Format**: aligned with the existing Cyber Risk GmbH entry (title with publisher in parentheses, short factual description)

Independent editorial project, no commercial offering on the site.