### PR TITLE
Add: EDPB Opinion 28/2024 on AI Models and GDPR

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   - [NIST AI Risk Management Framework](#nist-ai-risk-management-framework)
   - [CEN/CENELEC Standardization (JTC 21)](#cencenelec-standardization-jtc-21)
   - [ENISA Cybersecurity](#enisa-cybersecurity)
+  - [Data Protection Authorities](#data-protection-authorities)
   - [OECD & International](#oecd--international)
   - [IEEE Standards](#ieee-standards)
   - [UK ICO AI Guidance](#uk-ico-ai-guidance)
@@ -251,6 +252,10 @@
 
 - [Cybersecurity of AI and Standardisation (ENISA)](https://www.enisa.europa.eu/publications/cybersecurity-of-ai-and-standardisation) - Assessment of AI cybersecurity standards with gap analysis.
 - [Multilayer Framework for AI Cybersecurity (ENISA)](https://www.enisa.europa.eu/publications/multilayer-framework-for-good-cybersecurity-practices-for-ai) - Three-layer framework for securing AI systems.
+
+### Data Protection Authorities
+
+- [EDPB Opinion 28/2024 on AI Models and GDPR](https://www.edpb.europa.eu/our-work-tools/our-documents/opinion-board-art-64/opinion-282024-certain-data-protection-aspects_en) - EDPB position on AI model anonymity, legitimate interest as legal basis, and unlawful training data.
 
 ### OECD & International
 


### PR DESCRIPTION
Adds EDPB Opinion 28/2024 on data protection aspects of AI models, and creates a new "Data Protection Authorities" subsection under "Standards & Frameworks" to house it.

**What it is:** Opinion 28/2024, adopted 17 December 2024 by the European Data Protection Board at the request of the Irish Data Protection Commission. Covers three core questions: (1) when an AI model trained on personal data can be considered anonymous, (2) when legitimate interest can serve as a legal basis for training or deploying AI models, and (3) consequences of training a model on unlawfully processed personal data. The most authoritative EU-wide position on the AI Act / GDPR intersection to date.

**Why it belongs:** The list's "Related EU Regulations" section already flags GDPR as intersecting with the AI Act (Article 10 data governance), but no actual DPA guidance is currently included anywhere. Opinion 28/2024 is the most-cited document at this intersection — referenced in virtually every major law-firm guide on the list. The AI Act's data governance obligations cannot be operationalised without DPA guidance, so the gap is real.

**On the new subsection:** I propose `### Data Protection Authorities` under `## Standards & Frameworks` (between ENISA Cybersecurity and OECD & International). DPA guidance is functionally a parallel governance layer to the standards bodies already in this section. If you'd prefer a different home — e.g., folding it into an existing subsection or placing it elsewhere entirely — happy to revise. One follow-up PR is planned for this subsection (the EDPB AI topic page as a living index), so two entries to start.

**Checklist:**
- [x] Directly relevant to EU AI Act compliance
- [x] Publicly accessible
- [x] Working link
- [x] Not already listed
- [x] Description under 100 characters
- [x] Hyphen separator
- [x] Table of contents updated