### PR TITLE
Add EATF (Agent Trust Framework) to AI Agent Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 - [agent-security-harness](https://github.com/msaleme/red-team-blue-team-agent-fabric) - Adversarial testing framework for autonomous agents with EU AI Act crosswalks.
 - [Vaara](https://github.com/vaaraio/vaara) - Python library for runtime oversight of AI agents: intercepts tool calls, scores risk via heuristic and opt-in ML classifier, and writes hash-chained audit logs aligned with EU AI Act Article 14 (human oversight) and Article 12 (record-keeping). Apache 2.0.
 - [Nobulex](https://github.com/arian-gogani/nobulex) - Cryptographic audit trails for AI agent record-keeping.
+- [EATF — Agent Trust Framework](https://github.com/tyche-institute/eatf) - Open specification + TypeScript reference implementation for cryptographically verifiable AI agent self-attestation. Produces offline-verifiable Agent Evidence Packages (.aep) with RSASSA-PKCS1-v1_5 plus ML-DSA-65 post-quantum signatures, RFC 3161 timestamps, and OVERT 1.0 receipts. Ships offline `eatf-sign` + `eatf-verify` + `eatf-inspect` CLIs, conformance test vectors, and a JSON Schema for the AEP metadata envelope. Apache 2.0; DCO sign-off; no managed-service surface. Explicitly NOT an eIDAS trust service under Article 3(16); attestations are technical self-attestations, not QEAA under Article 3(45). Maintained by Tyche Institute (Estonian non-profit, in formation).
 
 ### AGT Implementation References
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@
 - [agent-security-harness](https://github.com/msaleme/red-team-blue-team-agent-fabric) - Adversarial testing framework for autonomous agents with EU AI Act crosswalks.
 - [Vaara](https://github.com/vaaraio/vaara) - Python library for runtime oversight of AI agents: intercepts tool calls, scores risk via heuristic and opt-in ML classifier, and writes hash-chained audit logs aligned with EU AI Act Article 14 (human oversight) and Article 12 (record-keeping). Apache 2.0.
 - [Nobulex](https://github.com/arian-gogani/nobulex) - Cryptographic audit trails for AI agent record-keeping.
-- [EATF — Agent Trust Framework](https://github.com/tyche-institute/eatf) - Open specification + TypeScript reference implementation for cryptographically verifiable AI agent self-attestation. Produces offline-verifiable Agent Evidence Packages (.aep) with RSASSA-PKCS1-v1_5 plus ML-DSA-65 post-quantum signatures, RFC 3161 timestamps, and OVERT 1.0 receipts. Ships offline `eatf-sign` + `eatf-verify` + `eatf-inspect` CLIs, conformance test vectors, and a JSON Schema for the AEP metadata envelope. Apache 2.0; DCO sign-off; no managed-service surface. Explicitly NOT an eIDAS trust service under Article 3(16); attestations are technical self-attestations, not QEAA under Article 3(45). Maintained by Tyche Institute (Estonian non-profit, in formation).
+- [EATF](https://github.com/tyche-institute/eatf) - Open specification and reference implementation for verifiable AI agent self-attestation.
 
 ### AGT Implementation References
 


### PR DESCRIPTION
Adding [EATF — Agent Trust Framework](https://github.com/tyche-institute/eatf) under the **AI Agent Governance** section (the project fits next to Vaara and Nobulex — same niche of cryptographic audit-trail tooling for AI agents under EU AI Act Article 12 / 14).

## What EATF is

- Open specification + TypeScript reference implementation for cryptographically verifiable AI agent self-attestation.
- Produces offline-verifiable **Agent Evidence Packages** (.aep) — small ZIPs with classical (RSASSA-PKCS1-v1_5) + post-quantum (ML-DSA-65) signatures, RFC 3161 timestamps, and OVERT 1.0 receipts.
- Ships offline CLIs: `eatf-sign`, `eatf-verify`, `eatf-inspect` (no network calls; no API keys).
- Conformance test vectors + a JSON Schema for the AEP metadata envelope.
- Apache 2.0; contribution via DCO sign-off; no managed-service surface (the framework is a library + spec, not a SaaS).

## Why it fits this list

EATF is built specifically for EU AI Act compliance — its design responds to Article 12 (record-keeping, Annex IV technical documentation), Article 14 (human oversight), and Article 50 (transparency obligations for AI systems interacting with humans). Each `.aep` is a self-contained, offline-verifiable piece of Annex-IV-grade evidence: an auditor can verify authenticity without contacting the operator.

## Positioning honesty

The project's NOTICE and `docs/aep-profile.md` are explicit that EATF is **not** an eIDAS trust service under Article 3(16) of Regulation (EU) 910/2014, and that agent attestations are technical self-attestations — not Qualified Electronic Attestations of Attributes (QEAA) under Article 3(45). The architecture distinguishes the technical attestation layer from any regulatory qualified-trust-service layer that operators may choose to layer on top.

## Maintainer

Tyche Institute, an Estonian non-profit research entity (in formation).

## Release status

- v0.1.0 — initial public scaffold (license, policies, structure)
- v0.1.1 — runnable offline verifier (lib + CLI + 4 vectors)
- v0.1.2 — inspect CLI + full wire-format spec
- v0.1.3 — offline signer + sign CLI + sign-then-verify round-trip CI

CI runs five required jobs on every push: schema validation, verifier unit tests, real-verifier conformance, sign-then-verify round-trip, and repository hygiene. DCO check runs on every PR.

Thank you for maintaining this list!