### PR TITLE
Add PRML / falsify to Reference Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@
 
 ### Reference Implementations
 
-- [PRML / falsify](https://spec.falsify.dev/v0.1) - Open specification (CC BY 4.0) for committing an ML evaluation claim to a SHA-256 hash before the experiment runs. Eight-field YAML, deterministic canonicalization, four byte-equivalent reference implementations (Python, JavaScript, Go, Rust). Subcategory crosswalk to [Article 12 logging](https://spec.falsify.dev/eu-ai-act/article-12/), [NIST AI RMF](https://spec.falsify.dev/nist-ai-rmf/), and [ISO/IEC 42001](https://spec.falsify.dev/iso-42001/). Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839), in [SchemaStore](https://www.schemastore.org/) catalog.
+- [PRML / falsify](https://spec.falsify.dev/v0.1) - Open specification for pre-registering ML evaluation claims as SHA-256 manifests before the experiment runs.
 - [Practical AI Act](https://github.com/aai-institute/practical-ai-act) - Implementation of a high-risk AI system per Chapter III using an open-source ML pipeline (Bavarian AI Act Accelerator).
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 
 ### Reference Implementations
 
+- [PRML / falsify](https://spec.falsify.dev/v0.1) - Open specification (CC BY 4.0) for committing an ML evaluation claim to a SHA-256 hash before the experiment runs. Eight-field YAML, deterministic canonicalization, four byte-equivalent reference implementations (Python, JavaScript, Go, Rust). Subcategory crosswalk to [Article 12 logging](https://spec.falsify.dev/eu-ai-act/article-12/), [NIST AI RMF](https://spec.falsify.dev/nist-ai-rmf/), and [ISO/IEC 42001](https://spec.falsify.dev/iso-42001/). Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839), in [SchemaStore](https://www.schemastore.org/) catalog.
 - [Practical AI Act](https://github.com/aai-institute/practical-ai-act) - Implementation of a high-risk AI system per Chapter III using an open-source ML pipeline (Bavarian AI Act Accelerator).
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@
 
 ### Reference Implementations
 
-- [PRML / falsify](https://spec.falsify.dev/v0.1) - Open specification for pre-registering ML evaluation claims as SHA-256 manifests before the experiment runs.
+- [PRML / falsify](https://spec.falsify.dev/v0.1) - Open specification for pre-registering ML evaluation claims with tamper-evident hashes.
 - [Practical AI Act](https://github.com/aai-institute/practical-ai-act) - Implementation of a high-risk AI system per Chapter III using an open-source ML pipeline (Bavarian AI Act Accelerator).
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.


### PR DESCRIPTION
PRML (Pre-Registered ML Manifest) is an open specification for committing an ML evaluation claim — metric, comparator, threshold, dataset hash, seed, producer identity — to a SHA-256 hash before the experiment runs. Adding it to **Reference Implementations** because it ships four byte-equivalent reference implementations of the spec (Python, JavaScript, Go, Rust).

Why it fits this list:
- CC BY 4.0 spec, MIT code, Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839)
- Subcategory crosswalk for [Article 12 automated logging](https://spec.falsify.dev/eu-ai-act/article-12/) (with explicit "interpretive mapping, not legal advice" disclaimer)
- Companion crosswalks for [NIST AI RMF 1.0](https://spec.falsify.dev/nist-ai-rmf/) and [ISO/IEC 42001:2023](https://spec.falsify.dev/iso-42001/)
- JSON Schema in the [SchemaStore catalog](https://www.schemastore.org/) (autocomplete in VS Code / JetBrains / Helix / Zed / Cursor)
- 20 conformance vectors passing byte-for-byte across all four implementations

The spec does not claim regulatory acceptance and the crosswalk pages carry the standard interpretive-mapping disclaimer. Open to revisions on section placement or framing.

Single-line addition under the existing Reference Implementations section. Happy to move to a different subsection if a better fit exists.