### PR TITLE
Add: AI Interaction Transparency Snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 - [Hyperproof](https://hyperproof.io/) - Compliance operations with automation for evidence collection and control mapping.
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
+- [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
 ---
 
 ## Open-Source Projects


### PR DESCRIPTION
## Summary
- Add AI Interaction Transparency Snippets to the EU AI Act-specific tools section

## Why
- The resource provides source-traced examples for AI-chat and synthetic-content notices
- The entry is one factual resource line and does not claim compliance or legal advice
