### PR TITLE
Add link to ISO 42001 Visual Library in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@
 ### ISO/IEC Standards
 
 - [ISO/IEC 42001:2023 - AI Management System](https://www.iso.org/standard/42001) - World's first certifiable AI management system standard (AIMS).
+- [ISO 42001 Visual Library](https://github.com/nelsambrose/ISO-42001-Visual-Library) - Visual learning library for ISO/IEC 42001:2023 covering clauses, Annex A controls, and the PDCA cycle through infographics.
 - [ISO/IEC 23894:2023 - AI Risk Management](https://www.iso.org/standard/84110.html) - AI-specific risk management guidance adapting ISO 31000 to AI system lifecycles.
 - [ISO/IEC 38507:2022 - Governance of AI](https://www.iso.org/standard/81283.html) - Governance guidance for organizational AI use and leadership accountability.
 - [ISO/IEC 42005:2025 - AI Impact Assessment](https://www.iso.org/standard/42005) - Framework for understanding AI system impacts on individuals, groups, and society.


### PR DESCRIPTION
Adds the ISO 42001 Visual Library under Standards & Frameworks > ISO/IEC Standards, as a companion learning resource to the existing ISO/IEC 42001:2023 entry.

## What are you adding or changing?

Adds one ISO 42001 Visual Library entry to the ISO/IEC Standards section.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The link is publicly accessible and currently working
- [x] The entry follows the format: `- [Name](URL) — One-sentence description.`
- [x] The description is factual and under 100 characters (no marketing language)
- [x] The resource is placed in the correct section
- [x] The resource is not already listed in the README
- [x] The resource is directly relevant to EU AI Act compliance or understanding