### PR TITLE
Add fmm-fairness-eval to Fairness Toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Practical templates, checklists, and assessment materials for AI Act readiness, 
 - [AI Fairness 360 (IBM/Linux Foundation)](https://github.com/Trusted-AI/AIF360) - 70+ fairness metrics and 10+ bias mitigation algorithms (~2,500 stars).
 - [Fairlearn (Microsoft)](https://github.com/fairlearn/fairlearn) - Assessing and improving fairness with group fairness metrics and mitigation algorithms (~1,900 stars).
 - [Aequitas (University of Chicago)](https://github.com/dssg/aequitas) - Bias and fairness audit toolkit across multiple population sub-groups.
+- [fmm-fairness-eval](https://github.com/Ces107/fmm-fairness-eval-cli) - SaMD-specific fairness CLI; treats hospital/site as a first-class protected attribute and maps metrics to AI Act Art. 9, 10, 15 with a SHA-256 audit chain.
 - [What-If Tool (Google)](https://pair-code.github.io/what-if-tool/) - Visual, interactive model analysis without code.
 - [Responsible AI Toolbox (Microsoft)](https://github.com/microsoft/responsible-ai-toolbox) - Unified dashboard combining Fairlearn, InterpretML, Error Analysis, and Counterfactual Analysis (~1,300 stars).
 


### PR DESCRIPTION
**Tool:** [fmm-fairness-eval](https://github.com/Ces107/fmm-fairness-eval-cli)
**PyPI:** `pip install --pre fmm-fairness-eval`
**License:** MIT

Proposed addition to the Fairness Toolkits subsection under AI Governance & Ethics Tools.

fmm-fairness-eval is a Python CLI for SaMD-specific fairness evaluation. The differentiator vs the existing entries (AIF360, Fairlearn, Aequitas) is two specific things:

1. It treats hospital or site as a first-class protected attribute. This is the dominant failure mode for medical AI that crosses hospital network boundaries (TFG underlying the tool measured a 0.19 inter-hospital F1 gap on AI4SkIN using CONCH embeddings), and no general-purpose fairness library handles it natively.
2. The output is a regulatory artifact, not just metrics. Each metric is cross-cited to the specific EU AI Act article it evidences (Art. 9 risk management, Art. 10 data governance, Art. 15 accuracy and robustness), and the whole pack ships with a SHA-256 audit chain for QMS pinning.

One entry under Fairness Toolkits, placed after Aequitas and before What-If Tool. No new section.

Per the contribution format I followed `[Name](url) - description.` in line with the existing entries. Happy to adjust phrasing if there's a preferred style I missed.