### PR TITLE
Add: Regulus to EU AI Act Compliance Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@
 - [ai-act-skills](https://github.com/abk1969/ai-act-skills) - Multi-platform agent skills for EU AI Act compliance workflows anchored in ISO/IEC 42001 and ISO/IEC 27090.
 - [VerifyWise](https://github.com/verifywise-ai/verifywise) - Complete AI governance and LLM evals platform with support for EU AI Act, ISO 42001, NIST AI RMF, and 20+ frameworks (~247 stars).
 - [EuConform](https://github.com/Hiepler/EuConform) - Risk classification, bias detection via CrowS-Pairs, and Annex IV-compliant PDF report generation, 100% offline (~107 stars).
+- [Regulus](https://github.com/neul-labs/regulus) - EU & UK compliance plane for Google ADK. Runtime `BasePlugin` suite encoding EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT as composable profiles with hash-chained audit envelopes and GRC adapters (ServiceNow IRM, OneTrust, MetricStream). Java 21, MIT.
 - [EU AI Act MCP Server](https://github.com/SonnyLabs/EU_AI_ACT_MCP) - MCP server with compliance tools including risk classification, prohibited practice checks, and transparency disclosures.
 - [MCP EU AI Act Scanner](https://github.com/ark-forge/mcp-eu-ai-act) - Scans codebases for EU AI Act and GDPR compliance gaps and generates auditor-ready Annex IV evidence packages.
 - [EU AI Act Compliance Checker](https://github.com/ARQNXS/eu-ai-act-compliance-checker) - Interactive web-based questionnaire for assessing compliance and generating reports.


### PR DESCRIPTION
Adds [Regulus](https://github.com/neul-labs/regulus) — the EU & UK compliance plane for Google ADK — to the **EU AI Act Compliance Platforms** section.

Regulus is a Java 21, MIT-licensed runtime ADK `BasePlugin` suite that encodes 10 regulations (EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT) and 6 governance frameworks (NIST AI RMF, ISO/IEC 42001, ISO/IEC 23894, ISO/IEC 23053) as composable profiles. It emits hash-chained audit envelopes and ships GRC evidence adapters (ServiceNow IRM, OneTrust AI Governance, MetricStream, signed webhooks).

It fits the section as a runtime implementation of EU AI Act Articles 9/10/50 + adjacent regimes for teams shipping Google ADK agents into EU/UK production.