### PR TITLE
Add AI Act Companion (open-source classifier) under Risk Assessment & Classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
 - [Regula](https://github.com/kuzivaai/getregula) - CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
+- [AI Act Companion](https://github.com/JKasteele/ai-act-companion) - Local-first, MIT-licensed risk classifier (prohibited/high/limited/minimal) with an architecture-aware AI-security lens (OWASP LLM Top 10, MITRE ATLAS, STRIDE); deterministic and cited, and generates DPIA, Annex IV, FRIA and a conformity tracker, with NIST AI RMF + ISO 42001 crosswalks. [Live demo](https://huggingface.co/spaces/JesseKasteele/ai-act-companion).
 
 ### Educational & Informational
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
 - [Regula](https://github.com/kuzivaai/getregula) - CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
-- [AI Act Companion](https://github.com/JKasteele/ai-act-companion) - Local-first risk classifier for EU AI Act obligations, with cited outputs and generated compliance documents.
+- [AI Act Companion](https://github.com/JKasteele/ai-act-companion) - Local-first EU AI Act risk classifier with cited results and document templates.
 
 ### Educational & Informational
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
 - [Regula](https://github.com/kuzivaai/getregula) - CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
-- [AI Act Companion](https://github.com/JKasteele/ai-act-companion) - Local-first, MIT-licensed risk classifier (prohibited/high/limited/minimal) with an architecture-aware AI-security lens (OWASP LLM Top 10, MITRE ATLAS, STRIDE); deterministic and cited, and generates DPIA, Annex IV, FRIA and a conformity tracker, with NIST AI RMF + ISO 42001 crosswalks. [Live demo](https://huggingface.co/spaces/JesseKasteele/ai-act-companion).
+- [AI Act Companion](https://github.com/JKasteele/ai-act-companion) - Local-first risk classifier for EU AI Act obligations, with cited outputs and generated compliance documents.
 
 ### Educational & Informational
 


### PR DESCRIPTION
Thanks for maintaining this list!

Adding **[AI Act Companion](https://github.com/JKasteele/ai-act-companion)** under *Open-Source Projects → Risk Assessment & Classification* — a free, MIT-licensed, local-first EU AI Act risk classifier.

Why it fits the open-source section:
- **Deterministic & cited** — every tier verdict links to the exact Article/Annex; a rule engine, not an LLM.
- **Architecture-aware AI-security lens** — OWASP LLM Top 10 + MITRE ATLAS + STRIDE, severity driven by the system architecture, plus a red-team plan and matching controls.
- Also generates DPIA, Annex IV technical docs, FRIA, a conformity tracker (Art. 99 penalties) and a post-market monitoring plan; NIST AI RMF + ISO/IEC 42001 crosswalks.
- [Live demo](https://huggingface.co/spaces/JesseKasteele/ai-act-companion) (synthetic data only); tests + CI; also ships as a Claude Code plugin and a GitHub Action.

Entry added at the end of the subsection, matching the existing format. Happy to tweak wording/placement — thanks for considering!