### PR TITLE
Add AI Law Radar (independent global AI-regulation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@
 - [EU Artificial Intelligence Act (Future of Life Institute)](https://artificialintelligenceact.eu/) - Most comprehensive independent resource; 150,000+ monthly users. Includes AI Act Explorer and Compliance Checker.
 - [AI Act Explorer (FLI)](https://artificialintelligenceact.eu/ai-act-explorer/) - Interactive browsing by title, chapter, article, and recital.
 - [EU AI Act Compliance Checker (FLI)](https://artificialintelligenceact.eu/assessment/eu-ai-act-compliance-checker/) - Free tool to determine whether an AI system falls under AI Act obligations.
-- [AI Law Radar](https://ailawradar.com) - Free, primary-sourced tracker of AI-law obligations and deadlines across 13 jurisdictions (EU AI Act + global): interactive map, dated register, open data (CC BY 4.0), a REST API + MCP server, and subscribe-once calendar feeds. Re-verified daily.
+- [AI Law Radar](https://ailawradar.com) - Primary-sourced tracker for AI regulation obligations and deadlines, including EU AI Act updates.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 - [EU Artificial Intelligence Act (Future of Life Institute)](https://artificialintelligenceact.eu/) - Most comprehensive independent resource; 150,000+ monthly users. Includes AI Act Explorer and Compliance Checker.
 - [AI Act Explorer (FLI)](https://artificialintelligenceact.eu/ai-act-explorer/) - Interactive browsing by title, chapter, article, and recital.
 - [EU AI Act Compliance Checker (FLI)](https://artificialintelligenceact.eu/assessment/eu-ai-act-compliance-checker/) - Free tool to determine whether an AI system falls under AI Act obligations.
+- [AI Law Radar](https://ailawradar.com) - Free, primary-sourced tracker of AI-law obligations and deadlines across 13 jurisdictions (EU AI Act + global): interactive map, dated register, open data (CC BY 4.0), a REST API + MCP server, and subscribe-once calendar feeds. Re-verified daily.
 
 ---
 


### PR DESCRIPTION
Adds [AI Law Radar](https://ailawradar.com) — a free, open (CC BY 4.0) tracker of AI-law obligations and deadlines across 13 jurisdictions. Every entry links to its primary source and is re-verified daily; there is a public REST API + MCP endpoint, an embeddable widget, and calendar/CSV export. Not legal advice. Thanks for maintaining this list!