### PR TITLE
Add CorvinOS — structural EU AI Act + GDPR enforcement for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@
 
 - [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) - Seven-package, MIT-licensed runtime governance system for autonomous AI agents covering all 10/10 OWASP Agentic Top 10 (2026) with EU AI Act, NIST AI RMF, HIPAA, and SOC 2 mappings. Enforces policy at <0.1ms p99 latency across LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK, and 8+ agent frameworks. Python, TypeScript, .NET, Rust, and Go (~900+ stars).
 - [agent-security-harness](https://github.com/msaleme/red-team-blue-team-agent-fabric) - Adversarial testing framework for autonomous agents with EU AI Act crosswalks.
+- [CorvinOS](https://github.com/CorvinLabs/CorvinOS) - Self-hosted agentic OS where EU AI Act Art. 50 bot-disclosure, GDPR Art. 30/32 hash-chained audit, and per-user consent gate (GDPR Art. 6/7) are structural architecture constraints — not configuration options. Apache-2.0, `pip install corvinos`.
 - [Vaara](https://github.com/vaaraio/vaara) - Python runtime evidence layer for AI agents: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable execution receipts, aligned with EU AI Act Article 14 (human oversight) and Article 12 (record-keeping). AGPL-3.0-or-later.
 - [Nobulex](https://github.com/arian-gogani/nobulex) - Cryptographic audit trails for AI agent record-keeping.
 - [EATF](https://github.com/tyche-institute/eatf) - Open specification and reference implementation for verifiable AI agent self-attestation.


### PR DESCRIPTION
## What

Adds [CorvinOS](https://github.com/CorvinLabs/CorvinOS) to the **AI Agent Governance** section.

## Why it fits

CorvinOS is the only entry in this list that enforces multiple EU AI Act and GDPR articles as **structural runtime constraints** rather than documentation or post-hoc compliance tools:

| Article | Mechanism | Enforcement property |
|---|---|---|
| EU AI Act Art. 50 | Bot-disclosure card | One-time per user · structurally fail-closed · no bypass path |
| EU AI Act Art. 5 | Acceptable-use gate (L44) | SHA-256-anchored policy · no kill-flag · no tenant override |
| GDPR Art. 6/7 | Consent gate | Deny-by-default · TTL-capped · re-validated at every turn |
| GDPR Art. 17 | Erasure orchestrator | Cross-layer · pseudonymous subject IDs · audit trail de-linked |
| GDPR Art. 30/32 | Hash-chained audit log | SHA-256 chain · daily auto-verify · chain write failure blocks request |

None of these can be disabled by an environment variable or config flag — they are load-bearing code.

CorvinOS also bridges Ollama and cloud LLMs to Discord, Telegram, WhatsApp, Slack, and Email, making it a practical self-hostable deployment target, not just a reference implementation.

- GitHub: https://github.com/CorvinLabs/CorvinOS (Apache-2.0, public since 2026-06-28)
- PyPI: https://pypi.org/project/corvinos/ (`pip install corvinos`)