### PR TITLE
Add Markovian audit-anchor (tamper-evident, independently verifiable audit trails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.
 - [AIR Blackbox](https://github.com/airblackbox) - Open-source trust infrastructure with 39 EU AI Act compliance checks, decision traceability, and audit chains across 11 PyPI packages.
+- [Markovian audit-anchor](https://github.com/MarkovianProtocol/audit-anchor) - Reference implementation making any audit trail tamper-evident and independently verifiable: canonicalize the log (RFC 8785), hash-chain it, commit the head to an external append-only timestamp (RFC 3161 or OpenTimestamps to Bitcoin), and verify offline by recomputation. Maps to record-keeping under Article 12.
 
 ### Risk Assessment & Classification
 


### PR DESCRIPTION
Adds [Markovian audit-anchor](https://github.com/MarkovianProtocol/audit-anchor).

It is an open-source reference implementation of independently verifiable, tamper-evident record integrity: canonicalize a log (RFC 8785), hash and Merkle-bind it, commit the root to an external append-only timestamp (RFC 3161 TSA or OpenTimestamps confirmed on Bitcoin), and verify offline with the stock client, with nothing trusted from the operator. It maps to record-keeping requirements such as EU AI Act Article 12. Thanks for maintaining this list.