### PR TITLE
Add EU AI Act Risk Checker to Open-Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@
 
 ### EU AI Act Compliance Platforms
 
+- [EU AI Act Risk Checker](https://github.com/tomdxb0004/eu-ai-act-risk-checker) - Client-side 4-question triage that classifies a system into its EU AI Act risk tier (prohibited/high/limited/minimal + GPAI) with obligations and compliance deadlines. No backend or tracking; bilingual EN/NL; MIT. [Live demo](https://cruxdigits.nl/eu-ai-act-risk-checker/).
 - [ai-act-conformity-pack](https://github.com/plusultra-tools/ai-act-conformity-pack) - Generates an Annex IV technical-documentation skeleton (Articles 11-15) from a YAML model card. Python CLI, MIT.
 - [ai-act-skills](https://github.com/abk1969/ai-act-skills) - Multi-platform agent skills for EU AI Act compliance workflows anchored in ISO/IEC 42001 and ISO/IEC 27090.
 - [VerifyWise](https://github.com/verifywise-ai/verifywise) - Complete AI governance and LLM evals platform with support for EU AI Act, ISO 42001, NIST AI RMF, and 20+ frameworks (~247 stars).


### PR DESCRIPTION
Adds **EU AI Act Risk Checker** to *Open-Source Projects → EU AI Act Compliance Platforms*.

A client-side, MIT-licensed 4-question triage that classifies an AI system into its EU AI Act risk tier — prohibited / high / limited / minimal, plus GPAI — and returns the resulting obligations and compliance deadlines. Based on Regulation (EU) 2024/1689. No backend, no tracking, bilingual EN/NL.

- Source (MIT): https://github.com/tomdxb0004/eu-ai-act-risk-checker
- Live demo: https://cruxdigits.nl/eu-ai-act-risk-checker/

Positioned as a fast triage, not legal advice. Happy to tweak wording or placement to fit the list.