### PR TITLE
Add Article 50 Code of Practice (Official EU Sources) and a drop-in Article 50 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - [Digital Omnibus on AI Regulation Proposal](https://digital-strategy.ec.europa.eu/en/library/digital-omnibus-ai-regulation-proposal) - Proposal to simplify AI Act implementation and adjust high-risk timelines.
 - [AI Act Standardisation](https://digital-strategy.ec.europa.eu/en/policies/ai-act-standardisation) - Official page on CEN/CENELEC harmonized standards in ten key areas.
 - [Supporting Implementation with Clear Guidelines](https://digital-strategy.ec.europa.eu/en/news/supporting-implementation-ai-act-clear-guidelines) - Published and upcoming guidelines on prohibited practices, high-risk classification, and transparency.
+* [Code of Practice on Transparency of AI-Generated Content](https://digital-strategy.ec.europa.eu/en/news/commission-publishes-code-practice-marking-and-labelling-ai-generated-content) - Final Code published 10 June 2026; voluntary reference implementation for Article 50 marking (providers) and labelling (deployers), open for signature.
 - [Guidelines on Prohibited AI Practices](https://digital-strategy.ec.europa.eu/en/library/commission-publishes-guidelines-prohibited-artificial-intelligence-ai-practices-defined-ai-act) - Commission's interpretation of Article 5 prohibitions with practical examples (4 February 2025).
 - [Guidelines on the Definition of an AI System](https://digital-strategy.ec.europa.eu/en/library/commission-publishes-guidelines-ai-system-definition-facilitate-first-ai-acts-rules-application) - Commission breakdown of the seven cumulative elements of the Article 3(1) AI system definition.
 - [Guidelines on the Scope of Obligations for Providers of GPAI Models](https://digital-strategy.ec.europa.eu/en/policies/guidelines-gpai-providers) - Commission interpretation of GPAI definition, the 10²³ FLOP threshold, and downstream-provider duties.
@@ -166,6 +167,7 @@
 - [AI Act Engineering](https://github.com/visenger/aiact-engineering) - Curated reference list for engineering practices ensuring AI systems comply with AI Act regulations.
 - [AI Act Technical Documentation Assessment Tools](https://github.com/Francesco-Sovrano/AI-Act-Compliance-Technical-Documentation-Assessment-Tools) - Research replication package for using AI to draft Annex IV-compliant technical documentation.
 - [AIR Blackbox](https://github.com/airblackbox) - Open-source trust infrastructure with 39 EU AI Act compliance checks, decision traceability, and audit chains across 11 PyPI packages.
+* [Article 50 Disclosure Code](https://github.com/seekdaseek/eu-ai-act-article-50) - Drop-in implementation of the Article 50 transparency duties: chatbot disclosure notice, AI-generated content badge, and an IPTC `trainedAlgorithmicMedia` XMP marker writer for JPEG and PNG. MIT.
 
 ### Risk Assessment & Classification
 


### PR DESCRIPTION
Two additions:

1. Official EU Sources is missing the Code of Practice on Transparency of AI-Generated Content — the Commission published the final version on 10 June 2026 and it's the reference implementation for Article 50 marking and labelling, ahead of the 2 August application date. Seemed like a gap worth closing regardless of the second item.

2. Reference Implementations currently covers Chapter III / Annex IV work. Adding a small MIT-licensed implementation of the Article 50 transparency duties: chatbot disclosure, AI-generated content badge, and an IPTC trainedAlgorithmicMedia XMP marker writer. Metadata alone is a floor rather than a full posture — the README says so and points at C2PA for the provenance layer.

Happy to drop item 2 and keep item 1 if you'd rather not list it.