### PR TITLE
Add Shim to EU AI Act-Specific Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
 - [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
+- [Shim](https://getshim.tech) - AI gateway enforcing compliance on the LLM request path: PII redaction before prompts reach providers (including Turkish TCKN/VKN), a tamper-evident hash-chain audit log with daily Merkle anchors for Article 12 record-keeping, human-oversight flagging, and Annex IV-style evidence reports.
 ---
 
 ## Open-Source Projects

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
 - [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
-- [Shim](https://getshim.tech) - AI gateway enforcing compliance on the LLM request path: PII redaction before prompts reach providers (including Turkish TCKN/VKN), a tamper-evident hash-chain audit log with daily Merkle anchors for Article 12 record-keeping, human-oversight flagging, and Annex IV-style evidence reports.
+- [Shim](https://getshim.tech) - AI gateway with PII redaction (incl. Turkish TCKN/VKN) and a tamper-evident Article 12 audit log.
 ---
 
 ## Open-Source Projects


### PR DESCRIPTION
## What are you adding or changing?

Adding [Shim](https://getshim.tech) to **Compliance Tools & Platforms → EU AI Act-Specific Tools**:

`- [Shim](https://getshim.tech) - AI gateway with PII redaction (incl. Turkish TCKN/VKN) and a tamper-evident Article 12 audit log.`

Why this section: the neighbours here (Vanta, FairNow, Kertos, ComplyACT) are compliance workspaces that document a system from the outside. Shim is a runtime component in the request path, so the Article 12 log is produced from traffic that actually passed through it rather than attested after the fact — and it covers the preventive half, redacting PII before prompts leave the perimeter. Placed under Compliance Tools rather than Open-Source Projects because it's commercial with public docs and a free tier.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The link is publicly accessible and currently working
- [x] The entry follows the format: `- [Name](URL) — One-sentence description.`
- [x] The description is factual and under 100 characters (no marketing language)
- [x] The resource is placed in the correct section
- [x] The resource is not already listed in the README
- [x] The resource is directly relevant to EU AI Act compliance or understanding

Disclosure: I work on Shim, so this is a self-submission — please weigh it accordingly, and close it without hesitation if it isn't the kind of entry you want here.