### PR TITLE
Add Reglog to Compliance Tools & Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
 - [Modulos](https://www.modulos.ai/) - Swiss-based AI governance platform connecting frameworks, requirements, controls, and evidence into a governance graph.
 - [Dataiku EU AI Act Readiness](https://www.dataiku.com/solutions/catalog/eu-ai-act-readiness/) - Governance workflow blueprints and compliance management.
 - [Fiddler AI](https://www.fiddler.ai/) - Full-stack AI observability with model monitoring, SHAP-based explainability, and fairness checks.
+- [Reglog](https://reglog.io) - Human-verified changelog of EU AI Act changes, cited to official sources, with obligation matching by role and risk tier
 
 ### EU AI Act-Specific Tools
 


### PR DESCRIPTION
Adds [Reglog](https://reglog.io) under Compliance Tools & Platforms — a human-verified changelog of EU AI Act changes (each entry cited to EUR-Lex/Official Journal), with a short assessment that maps obligations by role and risk tier, and tracks date changes like the Regulation (EU) 2026/1744 high-risk deferrals. Free tier; paid monitoring. Disclosure: I built it.

## What are you adding or changing?

<!-- Briefly describe the resource(s) you are adding or the change you are making. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The link is publicly accessible and currently working
- [x] The entry follows the format: `- [Name](URL) — One-sentence description.`
- [x] The description is factual and under 100 characters (no marketing language)
- [x] The resource is placed in the correct section
- [x] The resource is not already listed in the README
- [x] The resource is directly relevant to EU AI Act compliance or understanding
