### PR TITLE
Add: PALO Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@
 - [EU AI Act Compliance Checker](https://github.com/ARQNXS/eu-ai-act-compliance-checker) - Interactive web-based questionnaire for assessing compliance and generating reports.
 - [Compl-AI](https://github.com/compl-ai/compl-ai) - Compliance-centered LLM evaluation framework with technical interpretation of the AI Act and benchmarking suite covering six core principles.
 - [@eucomplyhub/mcp-eu-ai-act](https://github.com/eucomplyhub/mcp-eu-ai-act) - MCP server for EU AI Act risk classification and Annex III analysis.
+- [PALO Framework](https://github.com/sev7enITA/PALOframework) - Local-first EU AI Act risk tiering, FRIA, lifecycle controls, and evidence workflows.
 
 ### Reference Implementations
 


### PR DESCRIPTION
## What are you adding or changing?

Adds PALO Framework under **Open-Source Projects > EU AI Act Compliance Platforms**.

PALO is an MIT-licensed, local-first framework providing EU AI Act risk tiering, FRIA, lifecycle controls, and exportable governance evidence workflows.

## Validation

- Confirmed the repository link is public, active, and MIT-licensed
- Confirmed no existing PALO entry or open pull request
- Confirmed the description is factual and under 100 characters
- Ran `git diff --check`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The link is publicly accessible and currently working
- [x] The entry follows the format: `- [Name](URL) - One-sentence description.`
- [x] The description is factual and under 100 characters (no marketing language)
- [x] The resource is placed in the correct section
- [x] The resource is not already listed in the README
- [x] The resource is directly relevant to EU AI Act compliance or understanding
