### PR TITLE
Add: SetAIComply

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
 - [Kertos](https://www.kertos.io/) - EU-focused platform supporting EU AI Act, GDPR, and ISO 27001 with AI-driven automation.
 - [Hyperproof](https://hyperproof.io/) - Compliance operations with automation for evidence collection and control mapping.
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
+- [SetAIComply](https://www.setaicomply.com/tools/risk-checker) - Free client-side AI Act risk-tier checker in all 24 EU languages; embeddable.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
 - [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
 ---


### PR DESCRIPTION
## What are you adding or changing?

One resource: SetAIComply, added under Compliance Tools & Platforms > EU AI Act-Specific Tools, next to ComplyACT AI and FairNow.

It is a free EU AI Act risk-tier checker. Three sets of checkboxes cover Article 5 prohibited practices, Annex III high-risk use cases and Article 50 transparency; the result gives the likely tier with the applicable articles and the deadline in force after Regulation (EU) 2026/1744. No account and no signup, and the classification runs entirely in the visitor's browser. It is available in all 24 official EU languages and can be embedded by third-party sites through a documented iframe snippet.

On maturity, since this is a self-submission: the tool is in production and is already listed in morganrcu/awesome-eu-ai-act under Assessment & Classification.

On format: I used the hyphen separator that the README uses throughout rather than the em dash shown in the template, to stay consistent with the surrounding entries. Happy to switch if you prefer.

Disclosure: I work on SetAIComply. Happy to reword the entry, move it to another section, or close this if it isn't a fit.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The link is publicly accessible and currently working
- [x] The entry follows the format: `- [Name](URL) - One-sentence description.`
- [x] The description is factual and under 100 characters (no marketing language)
- [x] The resource is placed in the correct section
- [x] The resource is not already listed in the README
- [x] The resource is directly relevant to EU AI Act compliance or understanding