### PR TITLE
Add The AI Act Clock to EU AI Act-Specific Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
 - [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
-- [The AI Act Clock](https://ascentis-ai.com/ai-act-clock/) — Questionnaire returning binding AI Act obligations and dates; ruleset published as JSON, CC BY 4.0.
+- [The AI Act Clock](https://ascentis-ai.com/ai-act-clock/) - AI Act obligation and deadline questionnaire with an open JSON ruleset.
 ---
 
 ## Open-Source Projects

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
 - [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
+- [The AI Act Clock](https://ascentis-ai.com/ai-act-clock/) - Returns the obligations binding you by role, risk tier and timing, with each date's source and the evidence required; 29 obligations, EN/FR, ruleset published as JSON under CC BY 4.0.
 ---
 
 ## Open-Source Projects

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - [ComplyACT AI](https://complyactai.com/blog/software-for-compliance-management) - Auto-classifies AI systems, generates audit-ready Annex IV documentation, and provides continuous monitoring.
 - [AI Disclosure Kit](https://disclosekit.com) - Generates Article 50 disclosure templates for AI transparency notices.
 - [AI Interaction Transparency Snippets](https://github.com/NlDev-hub/ai-interaction-transparency-snippets) - Source-traced examples for AI-chat and synthetic-content notices.
-- [The AI Act Clock](https://ascentis-ai.com/ai-act-clock/) - Returns the obligations binding you by role, risk tier and timing, with each date's source and the evidence required; 29 obligations, EN/FR, ruleset published as JSON under CC BY 4.0.
+- [The AI Act Clock](https://ascentis-ai.com/ai-act-clock/) — Questionnaire returning binding AI Act obligations and dates; ruleset published as JSON, CC BY 4.0.
 ---
 
 ## Open-Source Projects


### PR DESCRIPTION
## What are you adding or changing?

Adding **The AI Act Clock** to *Compliance Tools & Platforms -> EU AI Act-Specific Tools*.

A free questionnaire that returns the AI Act obligations binding a given role and risk tier, each with its application date after the July 2026 Digital Omnibus and the evidence required. Bilingual (EN/FR), no sign-up.

The part likely most useful to this list is the underlying ruleset, published as a machine-readable dataset under CC BY 4.0: 29 obligations keyed to article, binding role, risk tier and application date, citing the consolidated EUR-Lex text and the Commission implementation timeline. Contested dates are flagged rather than silently resolved.

- Tool: https://ascentis-ai.com/ai-act-clock/
- Ruleset (JSON): https://ascentis-ai.com/ai-act-clock.json

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] The link is publicly accessible and currently working
- [x] The entry follows the format: `- [Name](URL) — One-sentence description.`
- [x] The description is factual and under 100 characters (no marketing language)
- [x] The resource is placed in the correct section
- [x] The resource is not already listed in the README
- [x] The resource is directly relevant to EU AI Act compliance or understanding