### PR TITLE
Add: EU AI Act Classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
 - [Regula](https://github.com/kuzivaai/getregula) - CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
+- [EU AI Act Classifier](https://github.com/sebastianfoerste/eu-ai-act-classifier) - Deterministic risk-tier classifier with pinpoint citations, obligation tracking, and review gates.
 
 ### Educational & Informational
 


### PR DESCRIPTION
Resubmission of #47, which was auto-closed in July when the head fork was deleted during a profile cleanup — not withdrawn for review reasons, and it received no review feedback. One resource, per the contribution guidelines.

Adds [eu-ai-act-classifier](https://github.com/sebastianfoerste/eu-ai-act-classifier) to **Open-Source Projects → Risk Assessment & Classification**.

**What it is:** a deterministic EU AI Act triage engine: gates-based risk-tier classification (Art. 5 prohibited practices, Art. 6 + Annex III high-risk incl. the Art. 6(3) derogation, GPAI, Art. 50 transparency) over a typed system profile, returning role-based obligations with pinpoint citations, the Art. 113 timeline, and a lawyer review gate for unsettled facts.

**Maturity evidence** (per the self-submission guidance): tagged releases; CI with a full test suite; committed sample output (`examples/classification-packet.md`/`.json`); citations verified against the consolidated EUR-Lex text down to Art. 5(1) letters and Annex III sub-points; local web cockpit under `web/`. Now MIT-licensed.

**Disclosure:** self-submitted by the author — German-qualified lawyer working in EU regulation; the classification logic and citations are hand-authored. Entry description is under 100 characters and factual.