### PR TITLE
Add EU AI Act Classifier to Risk Assessment & Classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - [AI Assessment Tool (AI4Belgium)](https://github.com/AI4Belgium/ai-assessment-tool) - Open-source interactive tool based on ALTAI recommendations for assessing AI trustworthiness.
 - [AI Act Implementation Tool (Algorithm Audit)](https://github.com/NGO-Algorithm-Audit/AI-Act-Implementation-Tool) - Risk classification of algorithmic systems using simplified questionnaires.
 - [Algoritmekader (Dutch Government)](https://github.com/MinBZK/Algoritmekader) - Netherlands' open-source Algorithm Framework for lawful and ethical government AI use.
+- [EU AI Act Classifier](https://github.com/sebastianfoerste/eu-ai-act-classifier) - Deterministic first-pass risk-tier classifier with cited obligations, binding timelines, and explicit human-review gates; CLI and MCP-style tools.
 - [Regula](https://github.com/kuzivaai/getregula) - CLI for EU AI Act risk scanning, conformity evidence packs, and CrowS-Pairs bias evaluation.
 
 ### Educational & Informational


### PR DESCRIPTION
Adding an open-source EU AI Act classifier under Open-Source Projects → Risk Assessment & Classification, alphabetically before Regula.

[eu-ai-act-classifier](https://github.com/sebastianfoerste/eu-ai-act-classifier) runs a gates-based review over a system profile and outputs the risk tier, the binding timeline, the applicable obligations, and the regulatory sources behind each — with pinpoint citations. The classification path is deterministic (no LLM), so the same input always produces the same result, and every output is staged for human review rather than presented as a conformity assessment.

CLI plus MCP-style tools, synthetic examples, runs offline via `uv run`, CI on main, MIT licensed.

Disclosure: I am the author. Happy to reword the description or move the entry if another section fits better.